### PR TITLE
fix: Add safe-area top padding for iOS status bar overlap

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -45,6 +45,7 @@
   --transition-base: 250ms ease;
   --transition-slow: 400ms ease;
   --safe-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-top: env(safe-area-inset-top, 0px);
 }
 
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -70,6 +71,7 @@ h1 { font-size: 1.75rem; } h2 { font-size: 1.375rem; } h3 { font-size: 1.125rem;
 
 .page {
   flex: 1; padding: var(--space-md);
+  padding-top: calc(var(--space-md) + var(--safe-top));
   padding-bottom: calc(80px + var(--safe-bottom) + var(--space-md));
   max-width: 600px; margin: 0 auto; width: 100%;
 }


### PR DESCRIPTION
This PR addresses the issue where the application content overlaps with the iOS status bar (top bar) on devices with notches.

### Changes:
- Added `env(safe-area-inset-top)` based padding to the `.page` container in `index.css`.
- Ensured a fallback of `0px` for non-iOS or older devices.
- Added `--safe-top` CSS variable to `:root`.

Verified by CSS inspection. Manual verification on a physical iOS device is recommended.