### PR TITLE
chore: cancel previous CI runs on new commits (#20)

### DIFF
--- a/.github/workflows/bdd-tests.yml
+++ b/.github/workflows/bdd-tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bdd-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/update-rewards.yml
+++ b/.github/workflows/update-rewards.yml
@@ -7,6 +7,10 @@ on:
   workflow_dispatch:
     # Allow manual trigger
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write


### PR DESCRIPTION
## Summary
This PR implements concurrency control in all GitHub Actions workflows to automatically cancel previous runs when new commits are pushed to the same branch or PR.

## Changes
- Added `concurrency` block to `bdd-tests.yml`
- Added `concurrency` block to `deploy.yml`
- Added `concurrency` block to `update-rewards.yml`

## Issue
Fixes #20