### PR TITLE
Fix Unused Perks UI clipping in Dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -128,19 +128,21 @@ export default function Dashboard() {
             <button className="btn btn-secondary btn-sm" onClick={() => navigate('/perks')}>View All</button>
           </div>
           {unusedPerks.slice(0, 5).map((perk: UserPerk) => (
-            <div key={perk.id} className="perk-item" onClick={() => navigate(`/card/${perk.cardId}`)}>
-              <div className="perk-info">
-                <div className="perk-name">{perk.perkName}</div>
-                <div className="perk-desc">{perk.renewalPeriod}</div>
-              </div>
-              {perk.periodValue ? (
-                <div style={{ textAlign: 'right' }}>
-                  <div className="perk-value">${perk.periodValue}</div>
-                  <div className="perk-period">/{perk.renewalPeriod === 'monthly' ? 'mo' : perk.renewalPeriod === 'quarterly' ? 'qtr' : 'period'}</div>
+            <div key={perk.id} className="perk-item">
+              <div className="perk-main-action" onClick={() => navigate(`/card/${perk.cardId}`)}>
+                <div className="perk-info">
+                  <div className="perk-name">{perk.perkName}</div>
+                  <div className="perk-desc">{perk.renewalPeriod}</div>
                 </div>
-              ) : perk.annualValue > 0 ? (
-                <div className="perk-value">${perk.annualValue}</div>
-              ) : null}
+                {perk.periodValue ? (
+                  <div style={{ textAlign: 'right' }}>
+                    <div className="perk-value">${perk.periodValue}</div>
+                    <div className="perk-period">/{perk.renewalPeriod === 'monthly' ? 'mo' : perk.renewalPeriod === 'quarterly' ? 'qtr' : 'period'}</div>
+                  </div>
+                ) : perk.annualValue > 0 ? (
+                  <div className="perk-value">${perk.annualValue}</div>
+                ) : null}
+              </div>
             </div>
           ))}
           {unusedPerks.length > 5 && (


### PR DESCRIPTION
Fixes #39

## Problem
The "Unused Perks This Period" section on the Dashboard was missing the `.perk-main-action` inner wrapper that other perk lists (Perks page, CardDetail page) use. Without it, the flexbox layout didn't apply proper padding and vertical centering, causing the value/period labels (e.g. `$10` / `/mo`) to stack and clip against the card border.

## Fix
Wrapped the perk item contents in `<div className="perk-main-action">` and moved the `onClick` navigation handler to that wrapper, consistent with how `CardDetail.tsx` and `Perks.tsx` handle perk items.

## Testing
All 38 BDD scenarios (199 steps) pass.