### PR TITLE
fix: add 5x Lyft earning rate to Chase Sapphire Preferred and Reserve

### DIFF
--- a/src/db/seed-data.ts
+++ b/src/db/seed-data.ts
@@ -15,6 +15,7 @@ export const cardTemplates: CardTemplate[] = [
     signupBonus: { points: 75000, spend: 5000, timeMonths: 3, unit: 'points' },
     earningRates: [
       { category: 'Chase Travel', multiplier: 5 },
+      { category: 'Lyft', multiplier: 5, limit: 'Through 9/30/2027' },
       { category: 'Dining', multiplier: 3 },
       { category: 'Streaming', multiplier: 3 },
       { category: 'Online Groceries', multiplier: 3 },
@@ -40,6 +41,7 @@ export const cardTemplates: CardTemplate[] = [
     signupBonus: { points: 125000, spend: 6000, timeMonths: 3, unit: 'points' },
     earningRates: [
       { category: 'Chase Travel', multiplier: 8 },
+      { category: 'Lyft', multiplier: 5, limit: 'Through 9/30/2027' },
       { category: 'Flights & Hotels (direct)', multiplier: 4 },
       { category: 'Dining', multiplier: 3 },
       { category: 'All Other', multiplier: 1 },


### PR DESCRIPTION
Closes #44

## Summary

Both Chase Sapphire Preferred and Chase Sapphire Reserve earn **5x points on Lyft rides** through 9/30/2027, but this was missing from their earning rates in `seed-data.ts`.

## Changes

- **Chase Sapphire Preferred**: Added `5x Lyft (Through 9/30/2027)` after Chase Travel (5x)
- **Chase Sapphire Reserve**: Added `5x Lyft (Through 9/30/2027)` after Chase Travel (8x)

This matches the same promotion already correctly listed on the Chase Ink Business Cash and Ink Business Preferred.