### PR TITLE
fix: show Lyft as vendor subcategory under Transit & Rideshare

### DIFF
--- a/src/utils/rewards.ts
+++ b/src/utils/rewards.ts
@@ -97,7 +97,7 @@ export function normalizeCategory(category: string): ParsedCategories {
     }
   }
 
-  if (cat.includes('transit') || cat.includes('rideshare') || cat.includes('lyft')) {
+  if (cat.includes('transit') || cat.includes('rideshare') || cat.includes('local transit')) {
     broad.push('Transit & Rideshare');
   }
 

--- a/tests/features/rewards-accuracy.feature
+++ b/tests/features/rewards-accuracy.feature
@@ -33,3 +33,10 @@ Feature: Rewards Accuracy
     Then I should see "Travel Portal" in the best card section with "Chase Sapphire Reserve" and "8x" multiplier
     And I should see "Flights" in the best card section with "Chase Sapphire Reserve" and "4x" multiplier
     And I should see "Hotels" in the best card section with "Chase Sapphire Reserve" and "4x" multiplier
+
+  Scenario: Lyft vendor subcategory under Transit & Rideshare
+    Given I have added the "Chase Sapphire Preferred" card
+    When I navigate to the "Dashboard"
+    Then I should see "Transit & Rideshare" on the dashboard
+    When I click to expand the "Transit & Rideshare" category
+    Then I should see the "Lyft" subcategory


### PR DESCRIPTION
Closes #46

## Problem
Chase cards have 5x Lyft rewards, but Lyft wasn't appearing as a vendor subcategory under "Transit & Rideshare" in the dashboard.

## Root Cause
In `normalizeCategory`, the condition `cat.includes('lyft')` caused a bare `'Lyft'` earning rate to map to **both** the broad `Transit & Rideshare` (5x) and the vendor `Lyft` (5x). Since subcategories only display when `vendor.multiplier > broad.multiplier`, Lyft was always suppressed.

## Fix
Removed `cat.includes('lyft')` from the broad Transit & Rideshare mapping — replaced with `cat.includes('local transit')` to correctly match category strings like `'Restaurants / Gas Stations / Local Transit'` (Amazon Visa).

```diff
-if (cat.includes('transit') || cat.includes('rideshare') || cat.includes('lyft')) {
+if (cat.includes('transit') || cat.includes('rideshare') || cat.includes('local transit')) {
```

Lyft is already handled as a vendor via `VENDOR_RULES`, so it now correctly appears as an expandable subcategory with 5x under Transit & Rideshare.

## Testing
Added BDD scenario: `Lyft vendor subcategory under Transit & Rideshare` in `rewards-accuracy.feature`. All 9 scenarios (51 steps) pass.