### PR TITLE
fix: Everything Else should show highest catch-all card (closes #48)

### DIFF
--- a/src/utils/rewards.ts
+++ b/src/utils/rewards.ts
@@ -86,7 +86,8 @@ export function normalizeCategory(category: string): ParsedCategories {
     if (isDirect || (!isPortal && !isDirect)) broad.push('Rental Cars');
   }
   
-  if (cat === 'travel' || cat === 'other travel' || (isPortal && !broad.includes('Travel Portal')) || (isDirect && !broad.some(r => r === 'Flights' || r === 'Hotels' || r === 'Rental Cars'))) {
+  const hasTravelWord = /\btravel\b/.test(cat);
+  if (cat === 'travel' || cat === 'other travel' || hasTravelWord || (isPortal && !broad.includes('Travel Portal')) || (isDirect && !broad.some(r => r === 'Flights' || r === 'Hotels' || r === 'Rental Cars'))) {
     const pushPortal = isPortal || (!isPortal && !isDirect);
     const pushDirect = isDirect || (!isPortal && !isDirect);
     if (pushPortal && !broad.includes('Travel Portal')) broad.push('Travel Portal');
@@ -131,9 +132,10 @@ export function normalizeCategory(category: string): ParsedCategories {
   }
 
   const uniqueBroad = Array.from(new Set(broad));
-  if (uniqueBroad.length === 0 && vendors.length === 0) {
-    uniqueBroad.push('Everything Else');
-  }
+  // Note: we intentionally do NOT fall back to 'Everything Else' here for unrecognized
+  // specific-category rates (e.g. "Office Supplies / Internet / Cable / Phone").
+  // The dedicated catch-all detection in getBestCardPerCategory handles "Everything Else"
+  // explicitly for true catch-all rates like "All Other" or "Everything".
 
   return { broad: uniqueBroad, vendors };
 }

--- a/tests/features/rewards-accuracy.feature
+++ b/tests/features/rewards-accuracy.feature
@@ -40,3 +40,9 @@ Feature: Rewards Accuracy
     Then I should see "Transit & Rideshare" on the dashboard
     When I click to expand the "Transit & Rideshare" category
     Then I should see the "Lyft" subcategory
+
+  Scenario: Everything Else shows highest catch-all card (issue #48)
+    Given I have added the "Capital One Venture" card
+    And I have added the "Chase Ink Business Preferred" card
+    When I navigate to the "Dashboard"
+    Then I should see "Everything Else" in the best card section with "Capital One Venture" and "2x" multiplier


### PR DESCRIPTION
## Problem

Fixes #48.

When a user has both Capital One Venture (2x on everything) and Chase Ink Business cards registered, the "Everything Else" category was incorrectly showing Ink Business instead of Venture.

## Root Cause

Two bugs in `normalizeCategory`:

**Bug 1 — Ink Preferred's 3x rate mapped to "Everything Else"**
Chase Ink Business Preferred has a rate category `'Travel / Shipping / Ads / Internet / Cable / Phone'` at 3x. The `travel` keyword check in `normalizeCategory` only matched exact strings like `'travel'` or `'other travel'`, not when `travel` appeared inside a slash-separated list. So this 3x rate fell through to "Everything Else", beating Venture's legitimate 2x.

**Bug 2 — Ink Cash's 5x office rate mapped to "Everything Else"**
Chase Ink Business Cash has `'Office Supplies / Internet / Cable / Phone'` at 5x. When a rate category doesn't match any known broad category, the old code fell back to assigning it to `'Everything Else'`. This caused this specific 5x rate to compete against (and beat) Venture's catch-all 2x.

## Fix

1. Added a `\btravel\b` word-boundary regex so rates like "Travel / Shipping / Ads..." now correctly map to Travel categories.
2. Removed the `'Everything Else'` fallback from `normalizeCategory`. Unrecognized specific-category rates are now simply ignored for broad-category tracking. The dedicated catch-all detection block in `getBestCardPerCategory` already handles "Everything Else" correctly for true catch-all rates (`'All Other'`, `'Everything'`, etc.).

## Tests

Added a BDD regression test in `rewards-accuracy.feature`.