### PR TITLE
style: remove background from settings button

### DIFF
--- a/src/components/SettingsMenu.tsx
+++ b/src/components/SettingsMenu.tsx
@@ -21,7 +21,8 @@ export function SettingsMenu() {
   return (
     <div className="dropdown" ref={menuRef}>
       <button 
-        className="btn btn-icon btn-secondary" 
+        className="btn btn-icon" 
+        style={{ background: 'none', border: 'none', color: 'var(--text-secondary)' }}
         onClick={() => setIsOpen(!isOpen)}
         aria-label="Settings"
       >


### PR DESCRIPTION
Removes the circular background and border from the settings three-dot button in the dashboard for a cleaner look.