### PR TITLE
fix(perks): ensure renewed perks stay active (#85)

### DIFF
--- a/src/db/helpers.ts
+++ b/src/db/helpers.ts
@@ -226,6 +226,7 @@ export async function syncCardPerks(): Promise<void> {
           renewalPeriod: inTemplate.renewalPeriod,
           annualValue: inTemplate.annualValue,
           periodValue: inTemplate.periodValue,
+          active: p.active !== false,
         });
       }
     }
@@ -287,7 +288,7 @@ export async function refreshExpiredPerks(): Promise<number> {
       annualValue: perkTemplate.annualValue,
       periodValue: perkTemplate.periodValue,
       used: false,
-      active: perk.active ?? (perkTemplate.requiresEnrollment ? false : true),
+      active: perk.active !== false,
       usedDate: undefined,
       currentPeriodStart: newPeriod.start,
       currentPeriodEnd: newPeriod.end,

--- a/tests/features/perk-persistence.feature
+++ b/tests/features/perk-persistence.feature
@@ -1,0 +1,29 @@
+Feature: Perk Activation Persistence
+  As a user I want my activated perks to stay active after renewal
+
+  Scenario: Explicitly activated perk stays active after renewal
+    Given I have added the "Chase Sapphire Reserve" card
+    When I view the card detail for "Chase Sapphire Reserve"
+    Then the "$5 DoorDash Restaurant Credit" perk should have an Activate button
+    When I activate the "$5 DoorDash Restaurant Credit" perk
+    Then the "$5 DoorDash Restaurant Credit" perk should not have an Activate button
+    
+    When the renewal period for "$5 DoorDash Restaurant Credit" expires
+    And the app refreshes expired perks
+    And I view the card detail for "Chase Sapphire Reserve"
+    
+    Then the "$5 DoorDash Restaurant Credit" perk should not have an Activate button
+    And the perk "$5 DoorDash Restaurant Credit" active status in DB should be "true"
+
+  Scenario: Implicitly active perk (from old version) stays active after renewal
+    Given I have added the "Chase Sapphire Reserve" card
+    When I view the card detail for "Chase Sapphire Reserve"
+    Then the "$300 Travel Credit" perk should not have an Activate button
+    
+    When the perk "$300 Travel Credit" has active set to undefined in DB
+    And the renewal period for "$300 Travel Credit" expires
+    And the app refreshes expired perks
+    Then the perk "$300 Travel Credit" active status in DB should be "true"
+    And I view the card detail for "Chase Sapphire Reserve"
+    
+    Then the "$300 Travel Credit" perk should not have an Activate button

--- a/tests/steps/perks.steps.ts
+++ b/tests/steps/perks.steps.ts
@@ -193,3 +193,25 @@ Then('the perk details modal should be closed', async function () {
   const modal = this.page.locator('.modal-content');
   await expect(modal).not.toBeVisible({ timeout: 5000 });
 });
+
+When('the perk {string} has active set to undefined in DB', async function (name: string) {
+  await this.page.evaluate(async (perkName: string) => {
+    const db = (window as unknown as { db: any }).db;
+    const allPerks = await db.perks.toArray();
+    const perk = allPerks.find(p => p.perkName === perkName);
+    if (!perk) throw new Error('Perk ' + perkName + ' not found');
+    const p = await db.perks.get(perk.id);
+    delete p.active;
+    await db.perks.put(p);
+  }, name);
+});
+
+Then('the perk {string} active status in DB should be {string}', async function (name: string, expected: string) {
+  const active = await this.page.evaluate(async (perkName: string) => {
+    const db = (window as unknown as { db: any }).db;
+    const allPerks = await db.perks.toArray();
+    const perk = allPerks.find(p => p.perkName === perkName);
+    return perk ? String(perk.active) : 'not found';
+  }, name);
+  expect(active).toBe(expected);
+});


### PR DESCRIPTION
Fixes #85. 

Previously, implicitly active perks (where the 'active' property was undefined) were being reset to inactive during renewal if they required enrollment. This PR ensures that any perk that was either explicitly or implicitly active remains active upon renewal.

Changes:
- src/db/helpers.ts: Ensure renewed perks stay active if they were already active or undefined.
- tests/steps/perks.steps.ts: Added helper steps for BDD tests to simulate undefined active status.
- tests/features/perk-persistence.feature: Added regression tests for perk activation persistence.