### PR TITLE
feat: add Amex Blue Business Plus card support

### DIFF
--- a/src/db/seed-data.ts
+++ b/src/db/seed-data.ts
@@ -248,9 +248,9 @@ export const cardTemplates: CardTemplate[] = [
       { category: 'All Other', multiplier: 1 },
     ],
     perks: [
-      { id: 'amex-bbp-buying-power', name: 'Expanded Buying Power', description: 'Spend beyond your credit limit', category: 'other', annualValue: 0, renewalPeriod: 'ongoing' },
-      { id: 'amex-bbp-protection', name: 'Purchase Protection', description: 'Coverage for items stolen or damaged within 90 days', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
-      { id: 'amex-bbp-warranty', name: 'Extended Warranty', description: 'Adds up to one additional year to manufacturer warranty', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'bbp-buying-power', name: 'Expanded Buying Power', description: 'Spend beyond your credit limit', category: 'other', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'bbp-protection', name: 'Purchase Protection', description: 'Coverage for items stolen or damaged within 90 days', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'bbp-warranty', name: 'Extended Warranty', description: 'Adds up to one additional year to manufacturer warranty', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
     ],
   },
 

--- a/src/db/seed-data.ts
+++ b/src/db/seed-data.ts
@@ -1,7 +1,7 @@
 import type { CardTemplate, ChurningRule } from './types';
 
 // ============================================================
-// Complete Card Catalog — 26 Cards
+// Complete Card Catalog — 27 Cards
 // ============================================================
 
 export const cardTemplates: CardTemplate[] = [
@@ -233,6 +233,24 @@ export const cardTemplates: CardTemplate[] = [
     ],
     perks: [
       { id: 'bbc-buying-power', name: 'Expanded Buying Power', description: 'Spend beyond your credit limit', category: 'other', annualValue: 0, renewalPeriod: 'ongoing' },
+    ],
+  },
+  {
+    id: 'amex-blue-business-plus',
+    name: 'Amex Blue Business® Plus',
+    issuer: 'Amex',
+    annualFee: 0,
+    color: '#003a70',
+    isBusinessCard: true,
+    signupBonus: { points: 15000, spend: 3000, timeMonths: 3, unit: 'points' },
+    earningRates: [
+      { category: 'All eligible purchases', multiplier: 2, limit: '$50K/yr' },
+      { category: 'All Other', multiplier: 1 },
+    ],
+    perks: [
+      { id: 'amex-bbp-buying-power', name: 'Expanded Buying Power', description: 'Spend beyond your credit limit', category: 'other', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'amex-bbp-protection', name: 'Purchase Protection', description: 'Coverage for items stolen or damaged within 90 days', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'amex-bbp-warranty', name: 'Extended Warranty', description: 'Adds up to one additional year to manufacturer warranty', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
     ],
   },
 

--- a/tests/features/card-catalog.feature
+++ b/tests/features/card-catalog.feature
@@ -4,7 +4,7 @@ Feature: Card Catalog
   Scenario: View all cards in the catalog
     Given I open the app
     When I navigate to the "Catalog"
-    Then I should see 26 cards in the catalog
+    Then I should see 27 cards in the catalog
 
   Scenario: Filter cards by issuer
     Given I am on the "Catalog" page
@@ -16,7 +16,7 @@ Feature: Card Catalog
   Scenario: Filter cards by Amex issuer
     Given I am on the "Catalog" page
     When I click the "Amex" filter button
-    Then I should see 8 cards in the catalog
+    Then I should see 9 cards in the catalog
 
   Scenario: Search cards by name
     Given I am on the "Catalog" page


### PR DESCRIPTION
Adds the American Express Blue Business Plus card to the catalog. Includes current May 2026 rewards (2x MR on first $50k) and key perks. Closes #94.