### PR TITLE
feat: add Chase Freedom and Freedom Flex card support (#102)

### DIFF
--- a/src/db/seed-data.ts
+++ b/src/db/seed-data.ts
@@ -1,7 +1,7 @@
 import type { CardTemplate, ChurningRule } from './types';
 
 // ============================================================
-// Complete Card Catalog — 27 Cards
+// Complete Card Catalog — 29 Cards
 // ============================================================
 
 export const cardTemplates: CardTemplate[] = [
@@ -64,6 +64,50 @@ export const cardTemplates: CardTemplate[] = [
       { id: 'csr-lounge', name: 'Airport Lounge Access', description: 'Priority Pass Select + Chase Sapphire Lounges + select Air Canada lounges', category: 'lounge-access', annualValue: 0, renewalPeriod: 'ongoing' },
       { id: 'csr-ihg', name: 'IHG Platinum Elite Status', description: 'Complimentary IHG One Rewards Platinum Elite (through 12/31/2027)', category: 'elite-status', annualValue: 0, renewalPeriod: 'annual', expirationDate: '2027-12-31' },
       { id: 'csr-trip-insurance', name: 'Travel Insurance Suite', description: 'Primary rental car, trip cancellation/delay, lost luggage, baggage delay, roadside assistance', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+    ],
+  },
+  {
+    id: 'chase-freedom-flex',
+    name: 'Chase Freedom Flex',
+    issuer: 'Chase',
+    annualFee: 0,
+    color: '#1a3c6e',
+    signupBonus: { points: 20000, spend: 500, timeMonths: 3, unit: 'cash back ($200)' },
+    earningRates: [
+      { category: 'Rotating Quarterly Categories (Activated)', multiplier: 5, limit: 'Up to $1,500/quarter' },
+      { category: 'Chase Travel', multiplier: 5 },
+      { category: 'Lyft', multiplier: 5, limit: 'Through 9/30/2027' },
+      { category: 'Dining', multiplier: 3 },
+      { category: 'Drugstores', multiplier: 3 },
+      { category: 'All Other', multiplier: 1 },
+    ],
+    perks: [
+      { id: 'cff-cell-protection', name: 'Cell Phone Protection', description: 'Up to $800 per claim ($1,000/year, max 2 claims/12mo, $50 deductible) against theft or damage when paying cell phone bill with card', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'cff-dashpass', name: 'DashPass 3-Month Trial', description: 'Complimentary 3 months of DashPass + 9 months at 50% off (through 12/31/2027)', category: 'membership', annualValue: 60, renewalPeriod: 'one-time', expirationDate: '2027-12-31', requiresEnrollment: true },
+      { id: 'cff-purchase-protection', name: 'Purchase Protection', description: 'Covers new purchases against damage/theft for 120 days, up to $500/item', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'cff-extended-warranty', name: 'Extended Warranty', description: 'Adds 1 year to eligible manufacturer warranties (3yr or less)', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'cff-trip-insurance', name: 'Trip Cancellation Insurance', description: 'Up to $1,500/traveler, $6,000/trip', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'cff-rental', name: 'Auto Rental Coverage', description: 'Secondary insurance for rental car theft and collision damage', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+    ],
+  },
+  {
+    id: 'chase-freedom',
+    name: 'Chase Freedom',
+    issuer: 'Chase',
+    annualFee: 0,
+    color: '#1a3c6e',
+    signupBonus: { points: 20000, spend: 500, timeMonths: 3, unit: 'cash back ($200)' },
+    earningRates: [
+      { category: 'Rotating Quarterly Categories (Activated)', multiplier: 5, limit: 'Up to $1,500/quarter' },
+      { category: 'Chase Travel', multiplier: 5 },
+      { category: 'Lyft', multiplier: 5, limit: 'Through 9/30/2027' },
+      { category: 'All Other', multiplier: 1 },
+    ],
+    perks: [
+      { id: 'cf-purchase-protection', name: 'Purchase Protection', description: 'Covers new purchases against damage/theft for 120 days, up to $500/item', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'cf-extended-warranty', name: 'Extended Warranty', description: 'Adds 1 year to eligible manufacturer warranties (3yr or less)', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'cf-trip-insurance', name: 'Trip Cancellation Insurance', description: 'Up to $1,500/traveler, $6,000/trip', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
+      { id: 'cf-rental', name: 'Auto Rental Coverage', description: 'Secondary insurance for rental car theft and collision damage', category: 'insurance', annualValue: 0, renewalPeriod: 'ongoing' },
     ],
   },
   {

--- a/tests/features/card-catalog.feature
+++ b/tests/features/card-catalog.feature
@@ -4,14 +4,16 @@ Feature: Card Catalog
   Scenario: View all cards in the catalog
     Given I open the app
     When I navigate to the "Catalog"
-    Then I should see 27 cards in the catalog
+    Then I should see 29 cards in the catalog
 
   Scenario: Filter cards by issuer
     Given I am on the "Catalog" page
     When I click the "Chase" filter button
-    Then I should see 7 cards in the catalog
+    Then I should see 9 cards in the catalog
     And I should see "Chase Sapphire Preferred"
     And I should see "Chase Sapphire Reserve"
+    And I should see "Chase Freedom Flex"
+    And I should see "Chase Freedom"
 
   Scenario: Filter cards by Amex issuer
     Given I am on the "Catalog" page
@@ -33,3 +35,12 @@ Feature: Card Catalog
     And I should see "Earning Rates"
     And I should see "Credits"
     And I should see "DashPass Membership" perk
+
+  Scenario: View Chase Freedom Flex details and perks from the catalog
+    Given I am on the "Catalog" page
+    When I click on the card "Chase Freedom Flex"
+    Then I should see "Chase Freedom Flex"
+    And I should see "Sign-up Bonus"
+    And I should see "Earning Rates"
+    And I should see "Cell Phone Protection" perk
+    And I should see "DashPass 3-Month Trial" perk


### PR DESCRIPTION
Closes #102

### Changes
- Added **Chase Freedom Flex** (`chase-freedom-flex`) to card catalog (`src/db/seed-data.ts`):
  - $0 Annual Fee, $200 (20,000 pts) bonus after $500 spend in 3 months
  - 5% on rotating quarterly categories up to $1,500/quarter upon activation
  - 5% on Chase Travel and 5% on Lyft (through 9/30/2027)
  - 3% on Dining and 3% on Drugstores
  - 1% on all other purchases
  - Perks: Cell Phone Protection ($800/claim, $50 deductible), DashPass 3-Month Trial, Purchase Protection, Extended Warranty, Trip Cancellation, Auto Rental Coverage
- Added **Chase Freedom** (`chase-freedom`) legacy card support:
  - 5% on rotating quarterly categories up to $1,500/quarter upon activation
  - 5% on Chase Travel and 5% on Lyft
  - 1% on all other purchases + standard protections
- Updated card catalog total count to 29 cards (9 Chase cards)
- Updated BDD tests in `tests/features/card-catalog.feature` to verify catalog counts and Chase Freedom Flex perks

### Verification
- Ran full BDD test suite: all 59 scenarios (332 steps) passed
- Built production bundle with `npm run build`