### PR TITLE
fix(test): use dynamic period expiration dates in perks BDD tests

### DIFF
--- a/tests/features/perks.feature
+++ b/tests/features/perks.feature
@@ -103,8 +103,8 @@ Feature: Perk Management
   Scenario: Verify annual renewal for The Edit hotel credit
     Given I have added the "Chase Sapphire Reserve" card
     When I view the card detail for "Chase Sapphire Reserve"
-    Then the "$250 \"The Edit\" Hotel Credit (1)" perk should expire on "2026-12-31"
-    And the "$300 Exclusive Tables Dining" perk should expire on "2026-06-30"
+    Then the "$250 \"The Edit\" Hotel Credit (1)" perk should expire on "the end of the year"
+    And the "$300 Exclusive Tables Dining" perk should expire on "the end of the current half"
 
   Scenario: Spend-based perks have activation controls
     Given I have added the "Citi® / AAdvantage® Platinum Select® World Elite Mastercard®" card

--- a/tests/steps/perks.steps.ts
+++ b/tests/steps/perks.steps.ts
@@ -66,13 +66,30 @@ Then('I should see no perks listed', async function () {
   }
 });
 
-Then('the {string} perk should expire on {string}', async function (perkName: string, expectedDate: string) {
+Then('the {string} perk should expire on {string}', async function (perkName: string, expectedDateStr: string) {
   const perkEnd = await this.page.evaluate(async (name: string) => {
     const db = (window as unknown as { db: { perks: { toArray: () => Promise<{ perkName: string; currentPeriodEnd: string }[]> } } }).db;
     const allPerks = await db.perks.toArray();
     const perk = allPerks.find((p: { perkName: string }) => p.perkName === name);
     return perk?.currentPeriodEnd;
   }, perkName);
+
+  let expectedDate = expectedDateStr;
+  const now = new Date();
+  const fmt = (d: Date) => d.toISOString().split('T')[0];
+  const lower = expectedDateStr.toLowerCase();
+  if (lower.includes('end of the year') || lower.includes('end of year')) {
+    expectedDate = fmt(new Date(now.getFullYear(), 11, 31));
+  } else if (lower.includes('end of the current half') || lower.includes('end of half') || lower.includes('semi-annual')) {
+    const h = now.getMonth() < 6 ? 5 : 11;
+    expectedDate = fmt(new Date(now.getFullYear(), h + 1, 0));
+  } else if (lower.includes('end of the current month') || lower.includes('end of month')) {
+    expectedDate = fmt(new Date(now.getFullYear(), now.getMonth() + 1, 0));
+  } else if (lower.includes('end of the current quarter') || lower.includes('end of quarter')) {
+    const q = Math.floor(now.getMonth() / 3) * 3 + 2;
+    expectedDate = fmt(new Date(now.getFullYear(), q + 1, 0));
+  }
+
   expect(perkEnd).toBe(expectedDate);
 });
 


### PR DESCRIPTION
## Summary
Fixes date-sensitive BDD test failures caused by hardcoded expiration dates for semi-annual and annual perks in `tests/features/perks.feature`.

## Problem
In `tests/features/perks.feature`, the CSR `$300 Exclusive Tables Dining` perk expiration was hardcoded to `"2026-06-30"`. When tests run in H2 (after June 30), `computePeriod('semi-annual')` dynamically calculates the end date as `"2026-12-31"`, causing tests on `main` and all rebased PRs to fail.

## Changes
- **`tests/steps/perks.steps.ts`**: Added support for dynamic period keywords (`"the end of the year"`, `"the end of the current half"`, `"the end of the month"`, `"the end of the quarter"`) while maintaining full backwards compatibility for literal dates.
- **`tests/features/perks.feature`**: Updated the scenario `Verify annual renewal for The Edit hotel credit` to assert dynamic period endpoints.

## Verification
- `npm run build` passed.
- `npm run test:bdd:run` passed: 57 scenarios passed, 315 steps passed.