### PR TITLE
feat: support downgrading and upgrading credit cards (closes #103)

### DIFF
--- a/src/components/ProductChangeModal.tsx
+++ b/src/components/ProductChangeModal.tsx
@@ -1,0 +1,372 @@
+import { useState } from 'react';
+import type { UserCard, CardTemplate } from '../db/types';
+import { getEligibleProductChangeTemplates, productChangeCard } from '../db/helpers';
+import { useToast } from './ToastContext';
+
+interface ProductChangeModalProps {
+  card: UserCard;
+  currentTemplate: CardTemplate;
+  onClose: () => void;
+  onSuccess: (newCardId: number, targetTemplate: CardTemplate) => void;
+}
+
+export function ProductChangeModal({
+  card,
+  currentTemplate,
+  onClose,
+  onSuccess,
+}: ProductChangeModalProps) {
+  const { showToast } = useToast();
+  const { upgrades, downgrades, sameTier, allEligible } = getEligibleProductChangeTemplates(currentTemplate.id);
+
+  const [selectedTab, setSelectedTab] = useState<'all' | 'upgrades' | 'downgrades' | 'sameTier'>('all');
+  const [selectedTemplate, setSelectedTemplate] = useState<CardTemplate | null>(null);
+  
+  // Customization fields for the target card
+  const [nickname, setNickname] = useState(card.nickname || '');
+  const [lastFour, setLastFour] = useState(card.lastFourDigits || '');
+  const [annualFeeDate, setAnnualFeeDate] = useState(card.annualFeeDate || '');
+  const [submitting, setSubmitting] = useState(false);
+
+  const displayedTemplates = selectedTab === 'upgrades'
+    ? upgrades
+    : selectedTab === 'downgrades'
+    ? downgrades
+    : selectedTab === 'sameTier'
+    ? sameTier
+    : allEligible;
+
+  const handleConfirmProductChange = async () => {
+    if (!selectedTemplate || !card.id) return;
+    setSubmitting(true);
+    try {
+      const newCardId = await productChangeCard(card.id, selectedTemplate.id, {
+        nickname: nickname.trim() || undefined,
+        lastFourDigits: lastFour.trim() || undefined,
+        annualFeeDate: annualFeeDate || undefined,
+      });
+
+      const isUpgrade = selectedTemplate.annualFee > currentTemplate.annualFee;
+      const isDowngrade = selectedTemplate.annualFee < currentTemplate.annualFee;
+      const actionType = isUpgrade ? 'Upgraded' : isDowngrade ? 'Downgraded' : 'Product changed';
+
+      showToast(`${actionType} to ${selectedTemplate.name}!`);
+      onSuccess(newCardId, selectedTemplate);
+    } catch (err) {
+      console.error('Error during product change:', err);
+      showToast('Failed to product change card');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const feeDifference = selectedTemplate
+    ? selectedTemplate.annualFee - currentTemplate.annualFee
+    : 0;
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div
+        className="modal-content"
+        onClick={e => e.stopPropagation()}
+        style={{ maxHeight: '90vh', display: 'flex', flexDirection: 'column' }}
+      >
+        <div className="modal-handle" />
+
+        {!selectedTemplate ? (
+          <>
+            <div className="flex justify-between items-center mb-sm">
+              <div>
+                <h3 style={{ fontSize: '1.25rem' }}>Product Change / Upgrade</h3>
+                <div className="text-xs text-muted mt-xs">
+                  Switch <span className="font-bold text-white">{currentTemplate.name}</span> to another {currentTemplate.issuer} card
+                </div>
+              </div>
+              <button
+                className="btn btn-secondary btn-sm"
+                onClick={onClose}
+                aria-label="Close modal"
+              >
+                ✕
+              </button>
+            </div>
+
+            {allEligible.length === 0 ? (
+              <div className="p-lg text-center text-muted">
+                <p>No other cards from {currentTemplate.issuer} are available for product change in the catalog.</p>
+                <button className="btn btn-secondary mt-md" onClick={onClose}>Close</button>
+              </div>
+            ) : (
+              <>
+                <div className="tabs mb-md" style={{ marginBottom: 12 }}>
+                  <button
+                    className={`tab ${selectedTab === 'all' ? 'active' : ''}`}
+                    onClick={() => setSelectedTab('all')}
+                  >
+                    All ({allEligible.length})
+                  </button>
+                  {upgrades.length > 0 && (
+                    <button
+                      className={`tab ${selectedTab === 'upgrades' ? 'active' : ''}`}
+                      onClick={() => setSelectedTab('upgrades')}
+                    >
+                      Upgrades ({upgrades.length})
+                    </button>
+                  )}
+                  {downgrades.length > 0 && (
+                    <button
+                      className={`tab ${selectedTab === 'downgrades' ? 'active' : ''}`}
+                      onClick={() => setSelectedTab('downgrades')}
+                    >
+                      Downgrades ({downgrades.length})
+                    </button>
+                  )}
+                  {sameTier.length > 0 && (
+                    <button
+                      className={`tab ${selectedTab === 'sameTier' ? 'active' : ''}`}
+                      onClick={() => setSelectedTab('sameTier')}
+                    >
+                      Same Tier ({sameTier.length})
+                    </button>
+                  )}
+                </div>
+
+                <div className="catalog-list" style={{ overflowY: 'auto', flex: 1, paddingRight: 4 }}>
+                  {displayedTemplates.map(targetTemplate => {
+                    const diff = targetTemplate.annualFee - currentTemplate.annualFee;
+                    const isUpgrade = diff > 0;
+                    const isDowngrade = diff < 0;
+
+                    return (
+                      <div
+                        key={targetTemplate.id}
+                        className="glass-card"
+                        style={{
+                          cursor: 'pointer',
+                          padding: '12px 14px',
+                          border: '1px solid rgba(255,255,255,0.08)',
+                          transition: 'all 0.2s ease',
+                        }}
+                        onClick={() => {
+                          setSelectedTemplate(targetTemplate);
+                          setNickname(targetTemplate.name);
+                        }}
+                      >
+                        <div className="flex items-center gap-md">
+                          <div
+                            style={{
+                              width: 44,
+                              height: 28,
+                              borderRadius: 4,
+                              background: targetTemplate.color,
+                              flexShrink: 0,
+                              position: 'relative',
+                              overflow: 'hidden',
+                              boxShadow: '0 2px 4px rgba(0,0,0,0.3)',
+                            }}
+                          >
+                            <div style={{ position: 'absolute', inset: 0, background: 'linear-gradient(135deg, rgba(255,255,255,0.2), transparent)' }} />
+                          </div>
+
+                          <div style={{ flex: 1, minWidth: 0 }}>
+                            <div className="font-bold flex items-center gap-xs" style={{ fontSize: '0.88rem' }}>
+                              <span>{targetTemplate.name}</span>
+                              {targetTemplate.isBusinessCard && (
+                                <span className="badge badge-blue" style={{ fontSize: '0.6rem', padding: '1px 4px' }}>Business</span>
+                              )}
+                            </div>
+                            <div className="text-xs text-muted">
+                              ${targetTemplate.annualFee}/yr • {targetTemplate.perks.length} perks
+                            </div>
+                          </div>
+
+                          <div style={{ textAlign: 'right', flexShrink: 0 }}>
+                            {isUpgrade && (
+                              <span className="badge badge-green" style={{ fontSize: '0.72rem' }}>
+                                +${diff}/yr Upgrade
+                              </span>
+                            )}
+                            {isDowngrade && (
+                              <span className="badge badge-blue" style={{ fontSize: '0.72rem' }}>
+                                -${Math.abs(diff)}/yr Downgrade
+                              </span>
+                            )}
+                            {diff === 0 && (
+                              <span className="badge badge-gold" style={{ fontSize: '0.72rem' }}>
+                                Same Fee ($0)
+                              </span>
+                            )}
+                          </div>
+                        </div>
+
+                        {targetTemplate.perks.filter(p => p.annualValue > 0).length > 0 && (
+                          <div className="mt-xs" style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                            {targetTemplate.perks
+                              .filter(p => p.annualValue > 0)
+                              .slice(0, 3)
+                              .map(p => (
+                                <span key={p.id} className="badge badge-gold" style={{ fontSize: '0.62rem', padding: '1px 5px' }}>
+                                  {p.name}
+                                </span>
+                              ))}
+                            {targetTemplate.perks.filter(p => p.annualValue > 0).length > 3 && (
+                              <span className="badge" style={{ fontSize: '0.62rem', padding: '1px 5px', opacity: 0.7 }}>
+                                +{targetTemplate.perks.filter(p => p.annualValue > 0).length - 3} more
+                              </span>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </>
+            )}
+          </>
+        ) : (
+          /* Confirmation & Review Screen */
+          <div style={{ overflowY: 'auto', flex: 1, paddingRight: 4 }}>
+            <button
+              className="btn btn-secondary btn-sm mb-md"
+              onClick={() => setSelectedTemplate(null)}
+              disabled={submitting}
+            >
+              ← Back to Card Options
+            </button>
+
+            <div className="flex items-center justify-between mb-sm">
+              <h3 style={{ fontSize: '1.2rem' }}>
+                {feeDifference > 0 ? 'Confirm Card Upgrade' : feeDifference < 0 ? 'Confirm Card Downgrade' : 'Confirm Product Change'}
+              </h3>
+              {feeDifference > 0 ? (
+                <span className="badge badge-green">Upgrade</span>
+              ) : feeDifference < 0 ? (
+                <span className="badge badge-blue">Downgrade</span>
+              ) : (
+                <span className="badge badge-gold">Lateral Change</span>
+              )}
+            </div>
+
+            {/* Visual Card Comparison */}
+            <div className="glass-card mb-md" style={{ padding: '16px' }}>
+              <div className="flex items-center justify-between gap-sm mb-md">
+                <div style={{ flex: 1, textAlign: 'center', padding: '10px', background: 'rgba(255,255,255,0.03)', borderRadius: '8px' }}>
+                  <div className="text-xs text-muted mb-xs">Current Card</div>
+                  <div className="font-bold text-sm">{currentTemplate.name}</div>
+                  <div className="text-xs text-muted mt-xs">${currentTemplate.annualFee}/yr</div>
+                </div>
+
+                <div style={{ fontSize: '1.5rem', opacity: 0.7 }}>➔</div>
+
+                <div style={{ flex: 1, textAlign: 'center', padding: '10px', background: 'rgba(255,255,255,0.06)', borderRadius: '8px', border: '1px solid rgba(255,255,255,0.1)' }}>
+                  <div className="text-xs text-gold mb-xs font-bold">New Card</div>
+                  <div className="font-bold text-sm">{selectedTemplate.name}</div>
+                  <div className="text-xs text-gold mt-xs font-bold">${selectedTemplate.annualFee}/yr</div>
+                </div>
+              </div>
+
+              {/* Annual Fee Impact Callout */}
+              <div
+                className="p-sm text-xs rounded mb-sm"
+                style={{
+                  background: feeDifference > 0 ? 'rgba(74, 222, 128, 0.1)' : feeDifference < 0 ? 'rgba(96, 165, 250, 0.1)' : 'rgba(255, 255, 255, 0.05)',
+                  border: `1px solid ${feeDifference > 0 ? 'rgba(74, 222, 128, 0.2)' : feeDifference < 0 ? 'rgba(96, 165, 250, 0.2)' : 'rgba(255, 255, 255, 0.1)'}`,
+                }}
+              >
+                {feeDifference > 0 ? (
+                  <span>
+                    📈 <strong>Annual fee will increase by ${feeDifference}/yr</strong> (${currentTemplate.annualFee} $\rightarrow$ ${selectedTemplate.annualFee}).
+                  </span>
+                ) : feeDifference < 0 ? (
+                  <span>
+                    📉 <strong>Annual fee will decrease by ${Math.abs(feeDifference)}/yr</strong> (${currentTemplate.annualFee} $\rightarrow$ ${selectedTemplate.annualFee}).
+                  </span>
+                ) : (
+                  <span>
+                    🔄 <strong>No change in annual fee</strong> (${currentTemplate.annualFee}/yr).
+                  </span>
+                )}
+              </div>
+
+              {/* Account Continuity Info */}
+              <ul className="text-xs text-muted" style={{ paddingLeft: '16px', margin: '8px 0', lineHeight: 1.6 }}>
+                <li>Account age (opened on <strong>{card.openedDate}</strong>) is preserved.</li>
+                <li>Previous card moves to <em>Closed / Product Changed</em> history.</li>
+                <li>New perks & earning rates activate immediately.</li>
+                <li>Per credit card rules, product changes do not earn a new sign-up bonus.</li>
+              </ul>
+            </div>
+
+            {/* Customization Form */}
+            <div className="glass-card mb-md" style={{ padding: '14px' }}>
+              <div className="font-bold text-xs text-muted mb-sm uppercase" style={{ letterSpacing: '0.5px' }}>
+                Card Customization
+              </div>
+
+              <div className="form-group mb-sm">
+                <label className="form-label" style={{ fontSize: '0.75rem' }}>Nickname</label>
+                <input
+                  className="form-input"
+                  value={nickname}
+                  onChange={e => setNickname(e.target.value)}
+                  placeholder={selectedTemplate.name}
+                  disabled={submitting}
+                />
+              </div>
+
+              <div className="flex gap-sm">
+                <div className="form-group" style={{ flex: 1 }}>
+                  <label className="form-label" style={{ fontSize: '0.75rem' }}>Last 4 Digits</label>
+                  <input
+                    className="form-input"
+                    value={lastFour}
+                    onChange={e => setLastFour(e.target.value.replace(/\D/g, '').slice(0, 4))}
+                    placeholder="1234"
+                    maxLength={4}
+                    disabled={submitting}
+                  />
+                </div>
+
+                <div className="form-group" style={{ flex: 1 }}>
+                  <label className="form-label" style={{ fontSize: '0.75rem' }}>Annual Fee Date</label>
+                  <input
+                    type="date"
+                    className="form-input"
+                    value={annualFeeDate}
+                    onChange={e => setAnnualFeeDate(e.target.value)}
+                    disabled={submitting}
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div className="flex gap-sm mt-md">
+              <button
+                className="btn btn-secondary"
+                style={{ flex: 1 }}
+                onClick={() => setSelectedTemplate(null)}
+                disabled={submitting}
+              >
+                Cancel
+              </button>
+              <button
+                className="btn btn-primary"
+                style={{ flex: 2 }}
+                onClick={handleConfirmProductChange}
+                disabled={submitting}
+              >
+                {submitting
+                  ? 'Processing...'
+                  : feeDifference > 0
+                  ? `Confirm Upgrade`
+                  : feeDifference < 0
+                  ? `Confirm Downgrade`
+                  : `Confirm Product Change`}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/db/helpers.ts
+++ b/src/db/helpers.ts
@@ -68,9 +68,16 @@ export function computePeriod(renewalPeriod: RenewalPeriod, now: Date = new Date
 
 // Expose to window for BDD testing
 if (typeof window !== 'undefined') {
-  const w = window as unknown as { refreshExpiredPerks: typeof refreshExpiredPerks; syncCardPerks: typeof syncCardPerks };
+  const w = window as unknown as {
+    refreshExpiredPerks: typeof refreshExpiredPerks;
+    syncCardPerks: typeof syncCardPerks;
+    productChangeCard: typeof productChangeCard;
+    getEligibleProductChangeTemplates: typeof getEligibleProductChangeTemplates;
+  };
   w.refreshExpiredPerks = refreshExpiredPerks;
   w.syncCardPerks = syncCardPerks;
+  w.productChangeCard = productChangeCard;
+  w.getEligibleProductChangeTemplates = getEligibleProductChangeTemplates;
 }
 
 // ── Card operations ──
@@ -147,6 +154,97 @@ export async function updateCard(
   updates: { nickname?: string; lastFourDigits?: string; annualFeeDate?: string }
 ): Promise<void> {
   await db.cards.update(cardId, updates);
+}
+
+export function getEligibleProductChangeTemplates(currentTemplateId: string): {
+  upgrades: CardTemplate[];
+  downgrades: CardTemplate[];
+  sameTier: CardTemplate[];
+  allEligible: CardTemplate[];
+} {
+  const currentTemplate = getCardTemplate(currentTemplateId);
+  if (!currentTemplate) return { upgrades: [], downgrades: [], sameTier: [], allEligible: [] };
+
+  // Eligible cards must be from the same issuer and not be the same card
+  const eligible = cardTemplates.filter(
+    c => c.issuer === currentTemplate.issuer && c.id !== currentTemplate.id
+  );
+
+  const upgrades = eligible.filter(c => c.annualFee > currentTemplate.annualFee);
+  const downgrades = eligible.filter(c => c.annualFee < currentTemplate.annualFee);
+  const sameTier = eligible.filter(c => c.annualFee === currentTemplate.annualFee);
+
+  return { upgrades, downgrades, sameTier, allEligible: eligible };
+}
+
+export async function productChangeCard(
+  cardId: number,
+  targetTemplateId: string,
+  options?: {
+    nickname?: string;
+    lastFourDigits?: string;
+    annualFeeDate?: string;
+  }
+): Promise<number> {
+  const oldCard = await db.cards.get(cardId);
+  if (!oldCard) throw new Error(`Card not found with ID: ${cardId}`);
+
+  const oldTemplate = getCardTemplate(oldCard.cardTemplateId);
+  const targetTemplate = getCardTemplate(targetTemplateId);
+
+  if (!oldTemplate || !targetTemplate) {
+    throw new Error('Invalid card template for product change');
+  }
+
+  if (oldTemplate.issuer !== targetTemplate.issuer) {
+    throw new Error(`Product change must be within the same publisher (${oldTemplate.issuer})`);
+  }
+
+  const today = new Date().toISOString().split('T')[0];
+
+  // 1. Update old card status to 'product-changed'
+  await db.cards.update(cardId, {
+    status: 'product-changed',
+    closedDate: today,
+  });
+
+  // 2. Remove old card's un-used perks so they do not linger in active perks tracker
+  await db.perks.where('cardId').equals(cardId).and(p => !p.used).delete();
+
+  // 3. Create new active card preserving account history
+  const newCardId = await db.cards.add({
+    cardTemplateId: targetTemplateId,
+    nickname: options?.nickname ?? (oldCard.nickname ? `${oldCard.nickname}` : undefined),
+    lastFourDigits: options?.lastFourDigits ?? oldCard.lastFourDigits,
+    openedDate: oldCard.openedDate, // Preserves original account age
+    annualFeeDate: options?.annualFeeDate ?? oldCard.annualFeeDate,
+    status: 'active',
+  } as UserCard);
+
+  // 4. Create new perks for the target template
+  const now = new Date();
+  const perksToAdd: UserPerk[] = targetTemplate.perks.map((p: PerkTemplate) => {
+    const period = computePeriod(p.renewalPeriod, now);
+    return {
+      cardId: newCardId as number,
+      perkTemplateId: p.id,
+      perkName: p.name,
+      category: p.category,
+      used: false,
+      active: p.requiresEnrollment ? false : true,
+      currentPeriodStart: period.start,
+      currentPeriodEnd: period.end,
+      renewalPeriod: p.renewalPeriod,
+      annualValue: p.annualValue,
+      periodValue: p.periodValue,
+    } as UserPerk;
+  });
+
+  await db.perks.bulkAdd(perksToAdd);
+
+  // Note: Product changes do not earn a sign-up bonus according to issuer rules.
+
+  return newCardId as number;
 }
 
 export async function updateBonusSpend(bonusId: number, newSpend: number): Promise<void> {

--- a/src/pages/CardDetail.tsx
+++ b/src/pages/CardDetail.tsx
@@ -7,6 +7,7 @@ import { CardHeader } from '../components/CardHeader';
 import { SignupBonusSection } from '../components/SignupBonusSection';
 import { EarningRatesSection } from '../components/EarningRatesSection';
 import { PerksSection } from '../components/PerksSection';
+import { ProductChangeModal } from '../components/ProductChangeModal';
 
 export default function CardDetail() {
   const { id } = useParams<{ id: string }>();
@@ -18,6 +19,7 @@ export default function CardDetail() {
   const perks = useLiveQuery(() => db.perks.where('cardId').equals(cardId).toArray(), [cardId]);
 
   const [showDelete, setShowDelete] = useState(false);
+  const [showProductChange, setShowProductChange] = useState(false);
 
   if (!card) return <div className="page"><p className="text-muted">Loading...</p></div>;
 
@@ -27,6 +29,11 @@ export default function CardDetail() {
   const handleDelete = async () => {
     await removeCard(cardId);
     navigate('/cards');
+  };
+
+  const handleProductChangeSuccess = (newCardId: number) => {
+    setShowProductChange(false);
+    navigate(`/card/${newCardId}`);
   };
 
   return (
@@ -41,9 +48,45 @@ export default function CardDetail() {
 
       {perks && <PerksSection perks={perks} template={template} />}
 
-      <div className="mt-lg">
-        <button className="btn btn-danger btn-block" onClick={() => setShowDelete(true)}>Remove Card</button>
-      </div>
+      {card.status === 'active' ? (
+        <div className="flex gap-sm mt-lg">
+          <button
+            className="btn btn-secondary"
+            style={{ flex: 1 }}
+            onClick={() => setShowProductChange(true)}
+          >
+            Upgrade / Downgrade
+          </button>
+          <button
+            className="btn btn-danger"
+            style={{ flex: 1 }}
+            onClick={() => setShowDelete(true)}
+          >
+            Remove Card
+          </button>
+        </div>
+      ) : (
+        <div className="mt-lg">
+          <div className="p-md glass-card text-center mb-md">
+            <span className="badge badge-red">{card.status}</span>
+            <p className="text-xs text-muted mt-sm">
+              This card was {card.status === 'product-changed' ? 'product changed to another card' : 'closed'}.
+            </p>
+          </div>
+          <button className="btn btn-danger btn-block" onClick={() => setShowDelete(true)}>
+            Remove Record
+          </button>
+        </div>
+      )}
+
+      {showProductChange && (
+        <ProductChangeModal
+          card={card}
+          currentTemplate={template}
+          onClose={() => setShowProductChange(false)}
+          onSuccess={handleProductChangeSuccess}
+        />
+      )}
 
       {showDelete && (
         <div className="modal-overlay" onClick={() => setShowDelete(false)}>

--- a/tests/features/product-change.feature
+++ b/tests/features/product-change.feature
@@ -1,0 +1,43 @@
+Feature: Product Change (Upgrading / Downgrading)
+  As a credit card holder
+  I want to upgrade or downgrade my cards to other products from the same publisher
+  So that I can optimize my perks and annual fees while maintaining my account history
+
+  Scenario: View product change options for same publisher only
+    Given I have added the "Chase Sapphire Preferred" card
+    When I view the card detail for "Chase Sapphire Preferred"
+    And I click "Upgrade / Downgrade"
+    Then I should see the product change modal
+    And I should see "Chase Sapphire Reserve" in the product change options
+    And I should see "Chase Freedom Unlimited" in the product change options
+    And I should not see "American Express Platinum" in the product change options
+    And I should not see "Capital One Venture X" in the product change options
+
+  Scenario: Upgrade a card to a higher annual fee product
+    Given I have added the "Chase Sapphire Preferred" card
+    When I view the card detail for "Chase Sapphire Preferred"
+    And I click "Upgrade / Downgrade"
+    And I select "Chase Sapphire Reserve" for product change
+    Then I should see "Confirm Card Upgrade"
+    When I confirm the product change
+    Then I should see "Chase Sapphire Reserve"
+    And I should see "$300 Travel Credit" in the perks list
+
+  Scenario: Downgrade a card to a lower annual fee product
+    Given I have added the "Chase Sapphire Reserve" card
+    When I view the card detail for "Chase Sapphire Reserve"
+    And I click "Upgrade / Downgrade"
+    And I select "Chase Freedom Unlimited" for product change
+    Then I should see "Confirm Card Downgrade"
+    When I confirm the product change
+    Then I should see "Chase Freedom Unlimited"
+
+  Scenario: Old card appears in Closed / Product Changed section on Cards page
+    Given I have added the "Chase Sapphire Preferred" card
+    When I view the card detail for "Chase Sapphire Preferred"
+    And I click "Upgrade / Downgrade"
+    And I select "Chase Sapphire Reserve" for product change
+    And I confirm the product change
+    And I navigate to the "Cards"
+    Then I should see "Chase Sapphire Reserve" on the cards page
+    And I should see "product-changed" in the closed cards section

--- a/tests/steps/product-change.steps.ts
+++ b/tests/steps/product-change.steps.ts
@@ -1,0 +1,38 @@
+import { When, Then } from '@cucumber/cucumber';
+import { expect } from '@playwright/test';
+
+Then('I should see the product change modal', async function () {
+  await this.page.waitForSelector('.modal-overlay', { state: 'visible', timeout: 5000 });
+  const heading = this.page.locator('.modal-content').getByText(/Product Change/i).first();
+  await expect(heading).toBeVisible({ timeout: 5000 });
+});
+
+Then('I should see {string} in the product change options', async function (cardName: string) {
+  const option = this.page.locator('.modal-content .glass-card').filter({ hasText: cardName }).first();
+  await expect(option).toBeVisible({ timeout: 5000 });
+});
+
+Then('I should not see {string} in the product change options', async function (cardName: string) {
+  const option = this.page.locator('.modal-content .glass-card').filter({ hasText: cardName });
+  await expect(option).toHaveCount(0);
+});
+
+When('I select {string} for product change', async function (cardName: string) {
+  const option = this.page.locator('.modal-content .glass-card').filter({ hasText: cardName }).first();
+  await option.waitFor({ state: 'visible', timeout: 5000 });
+  await option.scrollIntoViewIfNeeded();
+  await option.click();
+});
+
+When('I confirm the product change', async function () {
+  const confirmBtn = this.page.locator('.modal-content button.btn-primary').filter({ hasText: /Confirm/i }).first();
+  await confirmBtn.waitFor({ state: 'visible', timeout: 5000 });
+  await confirmBtn.click();
+  await this.page.waitForURL(/\/card\/\d+/, { timeout: 8000 });
+  await this.page.waitForTimeout(500);
+});
+
+Then('I should see {string} in the closed cards section', async function (statusText: string) {
+  const badge = this.page.locator('.badge-red').filter({ hasText: statusText }).first();
+  await expect(badge).toBeVisible({ timeout: 5000 });
+});


### PR DESCRIPTION
## Summary
Closes #103

Implements the feature to support upgrading, downgrading, and product-changing credit cards to other cards from the same publisher/issuer.

## Key Changes
- **Database & Helpers**:
  - Added `getEligibleProductChangeTemplates` in `src/db/helpers.ts` to filter and group eligible cards from the same issuer (Upgrades, Downgrades, Same Tier).
  - Added `productChangeCard` in `src/db/helpers.ts` to mark the previous card as `product-changed`, clean up unused perks, preserve account age (`openedDate`) and last 4 digits, and initialize new perks without creating duplicate sign-up bonuses.
- **UI Components**:
  - Created `ProductChangeModal.tsx` to allow intuitive selection between upgrades, downgrades, and lateral switches, previewing fee differences (`+$X/yr` or `-$X/yr`) and confirming account continuity.
  - Integrated the **Upgrade / Downgrade** action on `CardDetail.tsx` for active cards.
- **Testing (BDD)**:
  - Added `tests/features/product-change.feature` and `tests/steps/product-change.steps.ts`.
  - All 62 BDD scenarios (354 steps) pass.

## Verification
- `npm run test:bdd`: 100% pass (62/62 scenarios, 354/354 steps).
- `npm run build`: Type check and Vite production bundle passed.